### PR TITLE
Usa fragmento para mostrar imagem de produto

### DIFF
--- a/src/components/CartProduct/index.js
+++ b/src/components/CartProduct/index.js
@@ -1,6 +1,6 @@
 import React from "react";
-import checkoutMethods from "../../services/checkout";
 import { currencyFormatter, defaultImages } from "@nabstore/utils";
+import { ProductImageFragment } from "@nabstore/mfe-products";
 import { Button } from "@nabstore/styleguide";
 import { ProdutoTitle, Info, Value } from "./styles";
 import Card from "../Card";
@@ -13,8 +13,8 @@ const CartProduct = ({ produto, removeProductFromCartAction }) => {
     <Card className="card" key={produto.id}>
       <div className="d-flex flex-row  justify-content-around">
         <div className="d-flex justify-content-center">
-          <img
-            src={checkoutMethods.getImageUrl(produto.id)}
+          <ProductImageFragment
+            produtoId={produto.id}
             onError={(e) => (e.target.src = defaultImages.NO_IMAGE_URL)}
             className="img-thumbnail"
             alt={produto.nome}

--- a/src/services/checkout.js
+++ b/src/services/checkout.js
@@ -72,10 +72,6 @@ const getEstimativaEntrega = async (cep) => {
   return res.data;
 };
 
-const getImageUrl = (produtoId) => {
-  return `${process.env.SERVICE_CHECKOUT_BASE_URL}/produtos/${produtoId}/image`;
-};
-
 const checkoutMethods = {
   createCartao,
   createCompra,
@@ -83,7 +79,6 @@ const checkoutMethods = {
   fetchCompras,
   fetchCompraById,
   getEstimativaEntrega,
-  getImageUrl,
 };
 
 export default checkoutMethods;


### PR DESCRIPTION
# Descrição

Para não ter que usar uma rota do contexto de produtos no service-checkout, usa fragmento exportado do mfe-products para mostrar a imagem dos produtos no carrinho.

## PRs relacionadas
- https://github.com/nabstore/service-checkout/pull/2
- https://github.com/nabstore/mfe-products/pull/6