### PR TITLE
Aumenta largura do card de ultimas compras

### DIFF
--- a/src/fragments/LastPurchasesFragment/index.js
+++ b/src/fragments/LastPurchasesFragment/index.js
@@ -38,7 +38,7 @@ const LastPurchasesFragment = () => {
       </div>
       <div className="d-flex flex-wrap mt-3 justify-content-start">
         {compras.slice(0, 4).map((compra) => (
-          <Card style={{ width: "16rem" }} className="card" key={compra.id}>
+          <Card style={{ width: "18rem" }} className="card" key={compra.id}>
             <div className="card-body">
               <h5 className="card-title">
                 Feita em {new Date(compra.createdAt).toLocaleDateString()}


### PR DESCRIPTION
# Descrição

Quando uma compra de 4 dígitos é mostrada no card de últimas compras, o valor vai para a linha de baixo. Para que isso não ocorra, aumentei a largura do card para comportar valroes de 4 dígitos na mesma linha.